### PR TITLE
Fix NPE in offsets-for-timestamps

### DIFF
--- a/src/dvlopt/kafka/in.clj
+++ b/src/dvlopt/kafka/in.clj
@@ -497,7 +497,9 @@
    (reduce (fn reduce-offsets [offsets [topic-partition oat]]
              (assoc offsets
                     (K.-interop.clj/topic-partition topic-partition)
-                    (K.-interop.clj/offset-and-timestamp oat)))
+                    (if (nil? oat) 
+                      nil
+                      (K.-interop.clj/offset-and-timestamp oat))))
            {}
            (let [topic-partition->timestamp' (reduce-kv (fn reduce-timestamps [hmap topic-partition timestamp]
                                                           (assoc hmap


### PR DESCRIPTION
If there is no such offset for a timestamp in a certain partition, null
will be returned for that key. This case is now handled.

This fixes #9